### PR TITLE
Readd Meteor Filler

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -9,7 +9,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
@@ -44,11 +43,8 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int col = 0;
 
             float totalComponentWeight = meteor.getTotalComponentWeight();
-            System.out.println("totalComponentWeight: " +totalComponentWeight);
             float totalFillerWeight = meteor.getTotalFillerWeight();
-            System.out.println("totalFilerWeight: " + totalFillerWeight);
             int fillerChance = meteor.fillerChance;
-            System.out.println("fillerChance: " + fillerChance);
             List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
@@ -58,9 +54,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                 int yPos = 37 + 18 * row;
 
                 List<String> tooltips = new ArrayList<>();
-                float chance = component.getChance() / totalComponentWeight * (float)(1 - fillerChance /100.0);
-                System.out.println("block: " + stack.toString());
-                System.out.println("chance: " + chance);
+                float chance = component.getChance() / totalComponentWeight * (float)(1 - fillerChance / 100.0);
                 tooltips.add(I18n.format("nei.recipe.meteor.chance", getFormattedChance(chance)));
                 tooltips.add(I18n.format("nei.recipe.meteor.amount", getEstimatedAmount(chance, meteor.radius)));
                 this.outputs.add(new TooltipStack(stack, xPos, yPos, tooltips));
@@ -84,9 +78,9 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
                     row++;
                 }
 
-                sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));
-
-                if (sortedFiller.isEmpty()) {
+                if (!sortedFiller.isEmpty()) {
+                    sortedFiller.sort(Comparator.comparingInt(c -> -c.getChance()));
+                } else {
                     sortedFiller.add(new MeteorParadigmComponent(new ItemStack(Blocks.stone), 1));
                     totalFillerWeight = 1;
                 }

--- a/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/client/nei/NEIMeteorRecipeHandler.java
@@ -40,8 +40,8 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
             int row = 0;
             int col = 0;
 
-            float totalMeteorWeight = meteor.getTotalMeteorWeight();
-            List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.componentList);
+            float totalMeteorWeight = meteor.getTotalOreWeight();
+            List<MeteorParadigmComponent> sortedComponents = new ArrayList<>(meteor.oreList);
             sortedComponents.sort(Comparator.comparingInt(c -> -c.getChance()));
 
             for (MeteorParadigmComponent component : sortedComponents) {
@@ -112,7 +112,7 @@ public class NEIMeteorRecipeHandler extends TemplateRecipeHandler {
     @Override
     public void loadCraftingRecipes(ItemStack result) {
         for (MeteorParadigm meteor : getSortedMeteors()) {
-            if (meteor.componentList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
+            if (meteor.oreList.stream().anyMatch(m -> matchItem(result, m.getValidBlockParadigm()))) {
                 arecipes.add(new CachedMeteorRecipe(meteor, result));
             }
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.util.Arrays;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -41,9 +41,6 @@ public class Meteor {
                             m.cost,
                             m.filler,
                             m.fillerChance);
-                    System.out.println("ores: " + Arrays.toString(m.ores));
-                    System.out.println("filler: " + Arrays.toString(m.filler));
-                    System.out.println("fillerChance: " + m.fillerChance);
                 }
             } catch (FileNotFoundException e) {
                 e.printStackTrace();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/Meteor.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.Arrays;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -21,6 +22,8 @@ public class Meteor {
     public String focusModId;
     public String focusName;
     public int focusMeta;
+    private String[] filler;
+    private int fillerChance;
 
     public static void loadConfig() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -35,7 +38,12 @@ public class Meteor {
                             findItemStack(m.focusModId, m.focusName, m.focusMeta),
                             m.ores,
                             m.radius,
-                            m.cost);
+                            m.cost,
+                            m.filler,
+                            m.fillerChance);
+                    System.out.println("ores: " + Arrays.toString(m.ores));
+                    System.out.println("filler: " + Arrays.toString(m.filler));
+                    System.out.println("fillerChance: " + m.fillerChance);
                 }
             } catch (FileNotFoundException e) {
                 e.printStackTrace();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -49,13 +49,13 @@ public class MeteorParadigm {
         parseStringArray(componentArray, false);
     }
 
-    public void parseStringArray(String[] componentArray, boolean filler) {
+    public void parseStringArray(String[] blockArray, boolean filler) {
         List<MeteorParadigmComponent> addList = filler ? fillerList : componentList;
-        for (int i = 0; i < componentArray.length; ++i) {
-            String componentName = componentArray[i];
+        for (int i = 0; i < blockArray.length; ++i) {
+            String blockName = blockArray[i];
             boolean success = false;
 
-            Matcher matcher = itemNamePattern.matcher(componentName);
+            Matcher matcher = itemNamePattern.matcher(blockName);
             if (matcher.matches()) {
                 String modID = matcher.group(1);
                 String itemName = matcher.group(2);
@@ -69,7 +69,7 @@ public class MeteorParadigm {
                     success = true;
                 }
 
-            } else if ((matcher = oredictPattern.matcher(componentName)).matches()) {
+            } else if ((matcher = oredictPattern.matcher(blockName)).matches()) {
                 String oreDict = matcher.group(1);
                 int weight = Integer.parseInt(matcher.group(2));
 
@@ -84,8 +84,8 @@ public class MeteorParadigm {
 
             } else {
                 // Legacy config
-                String oreDict = componentName;
-                int weight = Integer.parseInt(componentArray[++i]);
+                String oreDict = blockName;
+                int weight = Integer.parseInt(blockArray[++i]);
 
                 List<ItemStack> list = OreDictionary.getOres(oreDict);
                 for (ItemStack stack : list) {
@@ -98,7 +98,7 @@ public class MeteorParadigm {
             }
 
             if (!success) {
-                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + componentName + "\"");
+                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + blockName + "\"");
             }
         }
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -20,7 +20,7 @@ import gregtech.common.blocks.TileEntityOres;
 
 public class MeteorParadigm {
 
-    public List<MeteorParadigmComponent> oreList = new ArrayList<>();
+    public List<MeteorParadigmComponent> componentList = new ArrayList<>();
     public List<MeteorParadigmComponent> fillerList = new ArrayList<>();
     public ItemStack focusStack;
     public int radius;
@@ -45,17 +45,17 @@ public class MeteorParadigm {
     // OREDICT:oreDictName:weight
     private static final Pattern oredictPattern = Pattern.compile("OREDICT:(.*):(\\d+)");
 
-    public void parseStringArray(String[] oreArray) {
-        parseStringArray(oreArray, false);
+    public void parseStringArray(String[] componentArray) {
+        parseStringArray(componentArray, false);
     }
 
-    public void parseStringArray(String[] oreArray, boolean filler) {
-        List<MeteorParadigmComponent> addList = filler ? fillerList : oreList;
-        for (int i = 0; i < oreArray.length; ++i) {
-            String oreName = oreArray[i];
+    public void parseStringArray(String[] componentArray, boolean filler) {
+        List<MeteorParadigmComponent> addList = filler ? fillerList : componentList;
+        for (int i = 0; i < componentArray.length; ++i) {
+            String componentName = componentArray[i];
             boolean success = false;
 
-            Matcher matcher = itemNamePattern.matcher(oreName);
+            Matcher matcher = itemNamePattern.matcher(componentName);
             if (matcher.matches()) {
                 String modID = matcher.group(1);
                 String itemName = matcher.group(2);
@@ -69,7 +69,7 @@ public class MeteorParadigm {
                     success = true;
                 }
 
-            } else if ((matcher = oredictPattern.matcher(oreName)).matches()) {
+            } else if ((matcher = oredictPattern.matcher(componentName)).matches()) {
                 String oreDict = matcher.group(1);
                 int weight = Integer.parseInt(matcher.group(2));
 
@@ -84,8 +84,8 @@ public class MeteorParadigm {
 
             } else {
                 // Legacy config
-                String oreDict = oreName;
-                int weight = Integer.parseInt(oreArray[++i]);
+                String oreDict = componentName;
+                int weight = Integer.parseInt(componentArray[++i]);
 
                 List<ItemStack> list = OreDictionary.getOres(oreDict);
                 for (ItemStack stack : list) {
@@ -98,14 +98,14 @@ public class MeteorParadigm {
             }
 
             if (!success) {
-                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + oreName + "\"");
+                AlchemicalWizardry.logger.warn("Unable to add Meteor Paradigm \"" + componentName + "\"");
             }
         }
     }
 
-    public int getTotalOreWeight() {
+    public int getTotalComponentWeight() {
         int totalWeight = 0;
-        for (MeteorParadigmComponent mpc : oreList) {
+        for (MeteorParadigmComponent mpc : componentList) {
             totalWeight += mpc.getChance();
         }
         return totalWeight;
@@ -150,7 +150,7 @@ public class MeteorParadigm {
 
         float totalChance = iceChance + soulChance + obsidChance;
 
-        int totalOreWeight = getTotalOreWeight();
+        int totalComponentWeight = getTotalComponentWeight();
         int totalFillerWeight = getTotalFillerWeight();
 
         for (int i = -newRadius; i <= newRadius; i++) {
@@ -165,7 +165,7 @@ public class MeteorParadigm {
                     }
 
                     if (world.rand.nextInt(100) >= fillerChance) {
-                        setMeteorBlock(x + i, y + j, z + k, world, oreList, totalOreWeight);
+                        setMeteorBlock(x + i, y + j, z + k, world, componentList, totalComponentWeight);
                     } else {
                         float randChance = rand.nextFloat() * totalChance;
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -1,7 +1,6 @@
 package WayofTime.alchemicalWizardry.common.summoning.meteor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.regex.Matcher;
@@ -18,7 +17,6 @@ import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.common.blocks.TileEntityOres;
-import org.lwjgl.Sys;
 
 public class MeteorParadigm {
 
@@ -211,9 +209,6 @@ public class MeteorParadigm {
     private void setMeteorBlock(int x, int y, int z, World world, List<MeteorParadigmComponent> blockList, int totalListWeight) {
         int randNum = world.rand.nextInt(totalListWeight);
         for (MeteorParadigmComponent mpc : blockList) {
-            System.out.println("block: " + mpc.getValidBlockParadigm());
-            System.out.println("chance: " + mpc.getChance());
-            System.out.println("randNum: " + randNum);
             randNum -= mpc.getChance();
 
             if (randNum < 0) {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorParadigm.java
@@ -194,7 +194,7 @@ public class MeteorParadigm {
                                 if (randChance < obsidChance) {
                                     world.setBlock(x + i, y + j, z + k, Blocks.obsidian, 0, 3);
                                 } else {
-                                    if (this.fillerList != null) {
+                                    if (!this.fillerList.isEmpty()) {
                                         setMeteorBlock(x + i, y + j, z + k, world, fillerList, totalFillerWeight);
                                     } else {
                                         world.setBlock(x + i, y + j, z + k, Blocks.stone, 0, 3);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -15,14 +15,14 @@ public class MeteorRegistry {
         paradigmList.add(paradigm);
     }
 
-    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost) {
-        registerMeteorParadigm(stack, oreList, radius, cost, null, 0);
+    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost) {
+        registerMeteorParadigm(stack, componentList, radius, cost, null, 0);
     }
 
-    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost, String[] fillerList, int fillerChance) {
-        if (stack != null && oreList != null) {
+    public static void registerMeteorParadigm(ItemStack stack, String[] componentList, int radius, int cost, String[] fillerList, int fillerChance) {
+        if (stack != null && componentList != null) {
             MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
-            meteor.parseStringArray(oreList);
+            meteor.parseStringArray(componentList);
             if (fillerList != null) {
                 meteor.parseStringArray(fillerList, true);
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/summoning/meteor/MeteorRegistry.java
@@ -16,9 +16,16 @@ public class MeteorRegistry {
     }
 
     public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost) {
+        registerMeteorParadigm(stack, oreList, radius, cost, null, 0);
+    }
+
+    public static void registerMeteorParadigm(ItemStack stack, String[] oreList, int radius, int cost, String[] fillerList, int fillerChance) {
         if (stack != null && oreList != null) {
-            MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost);
+            MeteorParadigm meteor = new MeteorParadigm(stack, radius, cost, fillerChance);
             meteor.parseStringArray(oreList);
+            if (fillerList != null) {
+                meteor.parseStringArray(fillerList, true);
+            }
             paradigmList.add(meteor);
         }
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -42,6 +42,11 @@ public class FallingTower {
     }
 
     @ZenMethod
+    public static void addFocus(IItemStack stack, int radius, int cost, String components, String filler, int fillerChance) {
+        MineTweakerAPI.apply(new Add(toStack(stack), radius, cost, components.split("\\s*,\\s*"), filler.split("\\s*,\\s*"), fillerChance));
+    }
+
+    @ZenMethod
     public static void removeFocus(IItemStack output) {
         MineTweakerAPI.apply(new Remove(toStack(output)));
     }
@@ -50,9 +55,16 @@ public class FallingTower {
 
         private MeteorParadigm paradigm;
 
-        public Add(ItemStack stack, int radius, int cost, String[] components) {
+        public Add(ItemStack stack, int radius, int cost, String[] ores) {
+            new Add(stack, radius, cost, ores, null, 0);
+        }
+
+        public Add(ItemStack stack, int radius, int cost, String[] ores, String[] filler, int fillerChance) {
             paradigm = new MeteorParadigm(stack, radius, cost);
-            paradigm.parseStringArray(components);
+            paradigm.parseStringArray(ores);
+            if (filler != null) {
+                paradigm.parseStringArray(filler, true);
+            }
         }
 
         @Override

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -55,13 +55,13 @@ public class FallingTower {
 
         private MeteorParadigm paradigm;
 
-        public Add(ItemStack stack, int radius, int cost, String[] ores) {
-            new Add(stack, radius, cost, ores, null, 0);
+        public Add(ItemStack stack, int radius, int cost, String[] components) {
+            new Add(stack, radius, cost, components, null, 0);
         }
 
-        public Add(ItemStack stack, int radius, int cost, String[] ores, String[] filler, int fillerChance) {
+        public Add(ItemStack stack, int radius, int cost, String[] components, String[] filler, int fillerChance) {
             paradigm = new MeteorParadigm(stack, radius, cost);
-            paradigm.parseStringArray(ores);
+            paradigm.parseStringArray(components);
             if (filler != null) {
                 paradigm.parseStringArray(filler, true);
             }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -65,6 +65,7 @@ public class FallingTower {
             if (filler != null) {
                 paradigm.parseStringArray(filler, true);
             }
+            paradigm.fillerChance = fillerChance;
         }
 
         @Override

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -268,6 +268,7 @@ nei.recipe.meteor.radius=Radius: %s
 nei.recipe.meteor.chance=Chance: %s%%
 nei.recipe.meteor.amount=Estimated amount: %s
 nei.recipe.meteor.filler=§7Filler block
+
 #Rituals
 ritual.AW001Water.name=Ritual of the Full Spring
 ritual.AW002Lava.name=Serenade of the Nether

--- a/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -267,7 +267,7 @@ nei.recipe.meteor.cost=Cost: %s LP
 nei.recipe.meteor.radius=Radius: %s
 nei.recipe.meteor.chance=Chance: %s%%
 nei.recipe.meteor.amount=Estimated amount: %s
-
+nei.recipe.meteor.filler=§7Filler block
 #Rituals
 ritual.AW001Water.name=Ritual of the Full Spring
 ritual.AW002Lava.name=Serenade of the Nether


### PR DESCRIPTION
Reimplement the concept of "filler" blocks to Blood Magic meteors.
Look for filler block list and fillerChance (chance for any individual block to be replaced with filler out of 100) in meteor config files in config/BloodMagic/meteors. Default filler block is minecraft:stone and default fillerChance is 0.
NEI meteor pages correctly show how much filler is expected in a meteor.
Fix an error in the block yield estimation function for more accurate results in NEI.